### PR TITLE
fix numpy warning getting through filters and breaking stdout

### DIFF
--- a/mordred/MolecularDistanceEdge.py
+++ b/mordred/MolecularDistanceEdge.py
@@ -1,4 +1,5 @@
 from six import string_types, integer_types
+import warnings
 from numpy import prod
 
 from ._base import Descriptor
@@ -85,7 +86,13 @@ class MolecularDistanceEdge(Descriptor):
         n = len(Dv)
 
         with self.rethrow_zerodiv():
-            dx = prod(Dv) ** (1.0 / (2.0 * n))
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="overflow encountered in reduce",
+                    category=RuntimeWarning,
+                )
+                dx = prod(Dv) ** (1.0 / (2.0 * n))
 
         return n / (dx**2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mordredcommunity"
-version = "2.0.2"
+version = "2.0.3"
 authors = [{ name = "Jackson Burns", email = "jwburns@mit.edu" }]
 license = { text = "BSD-3-Clause" }
 description = "Community-Maintained Version of mordred"
@@ -16,7 +16,7 @@ classifiers = [
 ]
 urls = { Homepage = "https://github.com/JacksonBurns/mordred-community" }
 requires-python = ">=3.8"
-dependencies = ["rdkit", "six", "numpy", "networkx"]
+dependencies = ["rdkit", "six", "numpy", "networkx", "packaging"]
 
 [project.optional-dependencies]
 full = ["pandas", "tqdm", "pyyaml"]


### PR DESCRIPTION
This PR should resolve #5 

I commented out [this line](https://github.com/JacksonBurns/mordred-community/blob/bd9efe7ee29d7841a1f3454089cdde1913c49c5b/mordred/_base/calculator.py#L257) in the calculator and then run python with `-Werror` to see where this warning was actually coming from, and then added a warning catch context manager there to prevent it from getting out.

In the future this warning catcher may have to go up a level to where the current broad `except` statement is, but that's a problem for another PR.
