### PR TITLE
Fix MDE overflow bug by computing the log of dx and then exponentiating

### DIFF
--- a/mordred/MolecularDistanceEdge.py
+++ b/mordred/MolecularDistanceEdge.py
@@ -1,6 +1,6 @@
 from six import string_types, integer_types
 import warnings
-from numpy import prod, longdouble
+import numpy as np
 
 from ._base import Descriptor
 from ._graph_matrix import Valence, DistanceMatrix
@@ -92,7 +92,8 @@ class MolecularDistanceEdge(Descriptor):
                     message="overflow encountered in reduce",
                     category=RuntimeWarning,
                 )
-                dx = prod(Dv, dtype=longdouble) ** (1.0 / (2.0 * n))
+                log_dx = np.sum(np.log(Dv)) / (2.0 * n)
+                dx = np.exp(log_dx)
 
         return n / (dx**2)
 


### PR DESCRIPTION
I see the line [here](https://github.com/JacksonBurns/mordred-community/blob/fdbd0d9121370f6e4bb3ffe4dd9f4d5b521c775b/mordred/MolecularDistanceEdge.py#L95C17-L95C69), namely `dx = prod(Dv, dtype=longdouble) ** (1.0 / (2.0 * n))`, was a response to an overflow error which led some Mordred descriptors to be silently equal to zero.

I still got an overflow error (and therefore silently equal to 0 descriptors) because of the `prod` for large enough SMILES strings such as `CCCCCC=CCCC(CCCCCCCC(=O)O)C(CCCCCCCC)CCCCCCCCC(=O)O`

This PR is a bugfix for this overflow error by computing `log_dx` first and then exponentiating to get `dx`:
```
log_dx = np.sum(np.log(Dv)) / (2.0 * n)
dx = np.exp(log_dx)
```

I think this change resolves the overflow issue.