### PR TITLE
ci: pin setup-micromamba to v3.2.1, resolve from conda-forge only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,15 @@ jobs:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} Subtest
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@main
+      # Pinned to a release tag instead of @main so the micromamba binary does
+      # not move under us. Uses conda-forge only: the 'defaults' channel let
+      # anaconda.com publish a tk 9.0.4 win-64 build (pulled in by python 3.14.7)
+      # that crashed micromamba on Windows with exit code 0xC0000005.
+      - uses: mamba-org/setup-micromamba@v3.2.1
         with:
           environment-name: temp
           condarc: |
             channels:
-              - defaults
               - conda-forge
             channel_priority: flexible
           create-args: |


### PR DESCRIPTION
## What
Scheduled CI has failed every weekday since Aug 17. Root cause: the 'defaults' channel (anaconda.com) published new python 3.14.7 / tk 9.0.4 win-64 builds between the Aug 14 (green) and Aug 17 (red) runs, and micromamba crashes with exit code 3221225477 (0xC0000005, access violation) while linking that tk build on windows-latest. Only the windows-latest Python 3.14 job is affected; the other 14 matrix jobs pass.

## Changes
- Pin mamba-org/setup-micromamba@v3.2.1 instead of @main (the action downloads the latest micromamba at runtime, so @main was a moving target)
- Drop the 'defaults' channel from condarc; resolve everything from conda-forge

## Why no Python pin
Verified against conda-forge repodata: all matrix versions (3.10-3.14) are available on win-64, linux-64 and osx-64, and conda-forge's python 3.14.7 win-64 build constrains tk to >=8.6.13,<8.7, which cannot pull the broken anaconda.com tk 9.0.4 build (hd2208ad_1). So pinning python is not needed once defaults is gone.